### PR TITLE
External Packages Rename Examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.class
 *.log
+target/
+project/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# scalafix-examples
+# ScalaFix Examples
+
+To run ExternalPackagesRename rule examples: 
+
+```
+> cd external-packages-name
+> sbt
+sbt:example> test:scalafix ExternalPackagesRename
+sbt:example> exit
+> git diff
+```
+
+You should see the package renaming diff done by ExternalPackagesRename rule.

--- a/external-packages-rename/build.sbt
+++ b/external-packages-rename/build.sbt
@@ -1,0 +1,19 @@
+lazy val example = Project("example", file(".")).settings(
+    name := "example",
+    organization := "org.scalatest",
+    version := "1.0.0",
+    scalaVersion := "2.12.8", 
+    libraryDependencies ++=
+    Seq(
+      "org.scalatest" %% "scalatest" % "3.0.6-SNAP-for-scalafix" % "test",
+      "org.scalacheck" %% "scalacheck" % "1.14.0" % "test",
+      "org.easymock" % "easymockclassextension" % "3.2" % "test",
+      "org.jmock" % "jmock-legacy" % "2.8.3" % "test",
+      "org.mockito" % "mockito-core" % "1.10.19" % "test",
+      "org.seleniumhq.selenium" % "selenium-java" % "2.45.0" % "test",
+      "junit" % "junit" % "4.12" % "test",
+      "org.testng" % "testng" % "6.7" % "test"
+    ), 
+    scalafixDependencies in ThisBuild += "org.scalatest" %% "external-packages-rename" % "1.0.0", 
+    addCompilerPlugin(scalafixSemanticdb) // enable SemanticDB
+)

--- a/external-packages-rename/project/build.properties
+++ b/external-packages-rename/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.7

--- a/external-packages-rename/project/plugins.sbt
+++ b/external-packages-rename/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.1")

--- a/external-packages-rename/src/test/scala/com/test/RenameAssertionsForJUnitSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameAssertionsForJUnitSpec.scala
@@ -1,0 +1,16 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.junit.AssertionsForJUnit
+
+class RenameAssertionsForJUnitSpec extends FunSuite with AssertionsForJUnit {
+
+  test("testing") {
+    val a = 1
+    assert(a == 1)
+  }
+
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameAsyncJMockCycleSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameAsyncJMockCycleSpec.scala
@@ -1,0 +1,35 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.jmock.AsyncJMockCycleFixture
+
+class RenameAsyncJMockCycleSpec extends fixture.AsyncFunSuite with AsyncJMockCycleFixture {
+
+  test("test example") { cycle =>
+    import cycle._
+    trait OneFish {
+      def eat(food: String): Unit = ()
+    }
+    trait TwoFish {
+      def eat(food: String): Unit = ()
+    }
+    val oneFishMock = mock[OneFish]
+    val twoFishMock = mock[TwoFish]
+
+    expecting { e => import e.{oneOf => OneOf}
+
+      OneOf (oneFishMock).eat("red fish")
+      OneOf (twoFishMock).eat("blue fish")
+    }
+
+    whenExecuting {
+      oneFishMock.eat("red fish")
+      twoFishMock.eat("green fish")
+    }
+
+    succeed
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameCheckersSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameCheckersSpec.scala
@@ -1,0 +1,14 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop.Checkers
+
+class RenameCheckersSpec extends FunSuite with Checkers {
+  
+  test("test concat") {
+    check((a: List[Int], b: List[Int]) => a.size + b.size == (a ::: b).size)
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameCheckersSpec2.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameCheckersSpec2.scala
@@ -1,0 +1,14 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop._
+
+class RenameCheckersSpec2 extends FunSuite with Checkers {
+  
+  test("test concat") {
+    check((a: List[Int], b: List[Int]) => a.size + b.size == (a ::: b).size)
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameCheckersSpec3.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameCheckersSpec3.scala
@@ -1,0 +1,14 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop.{Checkers, PropertyChecks}
+
+class RenameCheckersSpec3 extends FunSuite with Checkers {
+  
+  test("test concat") {
+    check((a: List[Int], b: List[Int]) => a.size + b.size == (a ::: b).size)
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameChromeSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameChromeSpec.scala
@@ -1,0 +1,15 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.selenium.{ WebBrowser, Chrome }
+
+class RenameChromeSpec extends FunSuite with WebBrowser with Chrome {
+
+  test("test example") {
+    go to "https://www.artima.com"
+    succeed
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameDriverSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameDriverSpec.scala
@@ -1,0 +1,24 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.selenium.{WebBrowser, Driver}
+
+trait RenameDriverSpec extends FunSpecLike with concurrent.Eventually { this: WebBrowser with Driver =>
+  describe("google.com") {
+
+    it("should change its title based on the term searched") {
+      // Cancel test when cannot access google.com
+      try goTo("http://www.google.com") catch { case e: Throwable => cancel(e) }
+      clickOn("q")
+      textField("q").value = "Cheese!"
+      submit()
+      // Google's search is rendered dynamically with JavaScript.
+      eventually(assert(pageTitle === "Cheese! - Google Search"))
+      close()
+    }
+
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameEasyMockSugarSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameEasyMockSugarSpec.scala
@@ -1,0 +1,35 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.easymock.EasyMockSugar
+
+class RenameEasyMockSugarSpec extends FunSuite with EasyMockSugar {
+
+  test("test example") {
+    trait OneFish {
+      def eat(food: String): Unit = ()
+    }
+    trait TwoFish {
+      def eat(food: String): Unit = ()
+    }
+    val oneFishMock = mock[OneFish]
+    val twoFishMock = mock[TwoFish]
+
+    expecting {
+      oneFishMock.eat("red fish")
+      twoFishMock.eat("blue fish")
+    }
+
+    // Trying the use case of passing an existing list of mocks for
+    // the heck of it.
+    val mocks = List(oneFishMock, twoFishMock)
+
+    whenExecuting(mocks: _*) {
+      oneFishMock.eat("red fish")
+      twoFishMock.eat("green fish")
+    }
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameFirefoxSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameFirefoxSpec.scala
@@ -1,0 +1,15 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.selenium.{WebBrowser, Firefox}
+
+class RenameFirefoxSpec extends FunSuite with WebBrowser with Firefox {
+
+  test("test example") {
+    go to "https://www.artima.com"
+    succeed
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameGeneratorDrivenPropertyChecksSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameGeneratorDrivenPropertyChecksSpec.scala
@@ -1,0 +1,16 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+class RenameGeneratorDrivenPropertyChecksSpec extends FunSuite with GeneratorDrivenPropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameGeneratorDrivenPropertyChecksSpec2.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameGeneratorDrivenPropertyChecksSpec2.scala
@@ -1,0 +1,16 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop._
+
+class RenameGeneratorDrivenPropertyChecksSpec2 extends FunSuite with GeneratorDrivenPropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameGeneratorDrivenPropertyChecksSpec3.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameGeneratorDrivenPropertyChecksSpec3.scala
@@ -1,0 +1,16 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop.{Checkers, GeneratorDrivenPropertyChecks}
+
+class RenameGeneratorDrivenPropertyChecksSpec3 extends FunSuite with GeneratorDrivenPropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameHtmlUnitSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameHtmlUnitSpec.scala
@@ -1,0 +1,15 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.selenium.{WebBrowser, HtmlUnit}
+
+class RenameHtmlUnitSpec extends FunSuite with WebBrowser with HtmlUnit {
+
+  test("test example") {
+    go to "https://www.artima.com"
+    succeed
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameInternetExplorerSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameInternetExplorerSpec.scala
@@ -1,0 +1,15 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.selenium.{WebBrowser, InternetExplorer}
+
+class RenameInternetExplorerSpec extends FunSuite with WebBrowser with InternetExplorer {
+
+  test("test example") {
+    go to "https://www.artima.com"
+    succeed
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameJMockCycleFixtureSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameJMockCycleFixtureSpec.scala
@@ -1,0 +1,33 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.jmock.JMockCycleFixture
+
+class RenameJMockCycleFixtureSpec extends fixture.FunSuite with JMockCycleFixture {
+
+  test("test example") { cycle =>
+    import cycle._
+    trait OneFish {
+      def eat(food: String): Unit = ()
+    }
+    trait TwoFish {
+      def eat(food: String): Unit = ()
+    }
+    val oneFishMock = mock[OneFish]
+    val twoFishMock = mock[TwoFish]
+
+    expecting { e => import e.{oneOf => OneOf}
+
+      OneOf (oneFishMock).eat("red fish")
+      OneOf (twoFishMock).eat("blue fish")
+    }
+
+    whenExecuting {
+      oneFishMock.eat("red fish")
+      twoFishMock.eat("green fish")
+    }
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameJMockCycleSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameJMockCycleSpec.scala
@@ -1,0 +1,33 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.jmock.{JMockCycleFixture, JMockCycle}
+
+class RenameJMockCycleSpec extends fixture.FunSuite with JMockCycleFixture {
+
+  test("test example") { cycle: JMockCycle =>
+    import cycle._
+    trait OneFish {
+      def eat(food: String): Unit = ()
+    }
+    trait TwoFish {
+      def eat(food: String): Unit = ()
+    }
+    val oneFishMock = mock[OneFish]
+    val twoFishMock = mock[TwoFish]
+
+    expecting { e => import e.{oneOf => OneOf}
+
+      OneOf (oneFishMock).eat("red fish")
+      OneOf (twoFishMock).eat("blue fish")
+    }
+
+    whenExecuting {
+      oneFishMock.eat("red fish")
+      twoFishMock.eat("green fish")
+    }
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameJMockExpectationsSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameJMockExpectationsSpec.scala
@@ -1,0 +1,33 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.jmock.{JMockExpectations, JMockCycleFixture}
+
+class RenameJMockExpectationsSpec extends fixture.FunSuite with JMockCycleFixture {
+
+  test("test example") { cycle =>
+    import cycle._
+    trait OneFish {
+      def eat(food: String): Unit = ()
+    }
+    trait TwoFish {
+      def eat(food: String): Unit = ()
+    }
+    val oneFishMock = mock[OneFish]
+    val twoFishMock = mock[TwoFish]
+
+    expecting { e => import e.{oneOf => OneOf}
+
+      (new JMockExpectations).oneOf (oneFishMock).eat("red fish")
+      (new JMockExpectations).oneOf (twoFishMock).eat("blue fish")
+    }
+
+    whenExecuting {
+      oneFishMock.eat("red fish")
+      twoFishMock.eat("green fish")
+    }
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameJUnit3SuiteSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameJUnit3SuiteSpec.scala
@@ -1,0 +1,10 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.junit.JUnit3Suite
+
+class RenameJUnit3SuiteSpec extends JUnit3Suite {
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameJUnitRunnerSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameJUnitRunnerSpec.scala
@@ -1,0 +1,15 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+
+class RenameJUnitRunnerSpec extends FunSuite {
+
+  test("testing") {
+    val suite = new FunSuite
+    val runner = new org.scalatest.junit.JUnitRunner(suite.getClass)
+  }
+
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameJUnitSuiteLikeSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameJUnitSuiteLikeSpec.scala
@@ -1,0 +1,10 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.junit.JUnitSuiteLike
+
+class RenameJUnitSuiteLikeSpec extends JUnitSuiteLike {
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameJUnitSuiteSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameJUnitSuiteSpec.scala
@@ -1,0 +1,10 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.junit.JUnitSuite
+
+class RenameJUnitSuiteSpec extends JUnitSuite {
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameJUnitTestFailedErrorSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameJUnitTestFailedErrorSpec.scala
@@ -1,0 +1,23 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+
+class RenameJUnitTestFailedErrorSpec extends FunSuite {
+
+  test("testing") {
+    val a = 1
+    if (a == 1)
+      succeed
+    else
+      throw new org.scalatest.junit.JUnitTestFailedError(
+        None,
+        None,
+        Right(0),
+        None
+      )
+  }
+
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameJUnitWrapperSuiteSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameJUnitWrapperSuiteSpec.scala
@@ -1,0 +1,15 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+
+class RenameJUnitWrapperSuiteSpec extends FunSuite {
+
+  test("testing") {
+    val s = new FunSuite
+    val juSuite = new org.scalatest.junit.JUnitWrapperSuite(s.getClass.getName, s.getClass.getClassLoader)
+  }
+
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameMockitoSugarSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameMockitoSugarSpec.scala
@@ -1,0 +1,23 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.mockito.MockitoSugar
+
+class RenameMockitoSugarSpec extends FunSuite with MockitoSugar {
+
+  test("test example") {
+    trait OneFish {
+      def eat(food: String): Unit = ()
+    }
+    trait TwoFish {
+      def eat(food: String): Unit = ()
+    }
+    val oneFishMock = mock[OneFish]
+    val twoFishMock = mock[TwoFish]
+
+    succeed
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenamePageSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenamePageSpec.scala
@@ -1,0 +1,17 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.selenium.Page
+
+class RenamePageSpec extends FunSuite {
+
+  test("test example") {
+    class TestPage extends Page {
+      val url = "https://www.artima.com/test.html"
+    }
+    succeed
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenamePropertyChecksSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenamePropertyChecksSpec.scala
@@ -1,0 +1,16 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop.PropertyChecks
+
+class RenamePropertyChecksSpec extends FunSuite with PropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenamePropertyChecksSpec2.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenamePropertyChecksSpec2.scala
@@ -1,0 +1,16 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop._
+
+class RenamePropertyChecksSpec2 extends FunSuite with PropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenamePropertyChecksSpec3.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenamePropertyChecksSpec3.scala
@@ -1,0 +1,16 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop.{Checkers, PropertyChecks}
+
+class RenamePropertyChecksSpec3 extends FunSuite with PropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameSafariSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameSafariSpec.scala
@@ -1,0 +1,15 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.selenium.{WebBrowser, Safari}
+
+class RenameSafariSpec extends FunSuite with WebBrowser with Safari {
+
+  test("test example") {
+    go to "https://www.artima.com"
+    succeed
+  }
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameTestNGSuiteLikeSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameTestNGSuiteLikeSpec.scala
@@ -1,0 +1,10 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.testng.TestNGSuiteLike
+
+class RenameTestNGSuiteLikeSpec extends TestNGSuiteLike {
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameTestNGSuiteSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameTestNGSuiteSpec.scala
@@ -1,0 +1,10 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.testng.TestNGSuite
+
+class RenameTestNGSuiteSpec extends TestNGSuite {
+}

--- a/external-packages-rename/src/test/scala/com/test/RenameTestNGWrapperSuiteSpec.scala
+++ b/external-packages-rename/src/test/scala/com/test/RenameTestNGWrapperSuiteSpec.scala
@@ -1,0 +1,15 @@
+/*
+rule = ExternalPackagesRename
+ */
+package test
+
+import org.scalatest._
+
+class RenameTestNGWrapperSuiteSpec extends FunSuite {
+
+  test("testing") {
+    val s = new FunSuite
+    val ngSuite = new org.scalatest.testng.TestNGWrapperSuite(List("suite.xml"))
+  }
+
+}


### PR DESCRIPTION
Examples for renaming using ExternalPackagesRename rule (from https://github.com/scalatest/scalatestplus-scalafix).